### PR TITLE
Update robot speech to use present participle verb format

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -177,7 +177,7 @@ function main() {
 
               if (timeSinceLastSpeech > 7000 || currentSpeech === '') {
                 // no-magic-numbers - new speech every 7 seconds
-                currentSpeech = buzzphrase.get({ format: '{V} {a} {N}' }); // no-undef - generate new buzzphrase
+                currentSpeech = buzzphrase.get({ format: '{V} {a} {N}', iterations: 1 }); // no-undef - generate new buzzphrase
                 speechStartTime = now;
                 lastSpeechTime = now;
                 // logger.info('Robot says: ' + currentSpeech); // Commented out to keep terminal clean

--- a/src/index.js
+++ b/src/index.js
@@ -177,7 +177,7 @@ function main() {
 
               if (timeSinceLastSpeech > 7000 || currentSpeech === '') {
                 // no-magic-numbers - new speech every 7 seconds
-                currentSpeech = buzzphrase.get(); // no-undef - generate new buzzphrase
+                currentSpeech = buzzphrase.get('presentTenseVerb'); // no-undef - generate new buzzphrase
                 speechStartTime = now;
                 lastSpeechTime = now;
                 // logger.info('Robot says: ' + currentSpeech); // Commented out to keep terminal clean
@@ -421,7 +421,7 @@ function main() {
     ); // no-console
 
     // Show robot speech in static demo
-    const robotSpeech = buzzphrase.get(); // no-var
+    const robotSpeech = buzzphrase.get('presentTenseVerb'); // no-var
     console.log(
       '\x1b[93m💬 Robot says:\x1b[0m \x1b[97m"' + robotSpeech + '"\x1b[0m'
     ); // no-console

--- a/src/index.js
+++ b/src/index.js
@@ -177,7 +177,7 @@ function main() {
 
               if (timeSinceLastSpeech > 7000 || currentSpeech === '') {
                 // no-magic-numbers - new speech every 7 seconds
-                currentSpeech = buzzphrase.get('presentTenseVerb'); // no-undef - generate new buzzphrase
+                currentSpeech = buzzphrase.get({ format: '{V} {a} {N}' }); // no-undef - generate new buzzphrase
                 speechStartTime = now;
                 lastSpeechTime = now;
                 // logger.info('Robot says: ' + currentSpeech); // Commented out to keep terminal clean
@@ -421,7 +421,7 @@ function main() {
     ); // no-console
 
     // Show robot speech in static demo
-    const robotSpeech = buzzphrase.get('presentTenseVerb'); // no-var
+    const robotSpeech = buzzphrase.get({ format: '{V} {a} {N}' }); // no-var
     console.log(
       '\x1b[93m💬 Robot says:\x1b[0m \x1b[97m"' + robotSpeech + '"\x1b[0m'
     ); // no-console


### PR DESCRIPTION
## Summary
- Updates Matrix Robot Demo speech to use more dynamic present participle verb format
- Changes from default buzzphrase format to `{V} {a} {N}` with iterations: 1

## Changes Made
- **Enhanced Robot Speech**: Robot now speaks action-oriented phrases like "optimizing distributed algorithms" instead of passive past-tense phrases
- **Format Specification**: Uses present participle verbs (`{V}`) + adjectives (`{a}`) + plural nouns (`{N}`)
- **Consistent Timing**: Maintains existing 7-second speech cycle

## Examples
**Before**: "architected multivariat alignments" (past-tense, passive)
**After**: "optimizing distributed algorithms" (present participle, active)

## Test plan
- [x] Verify robot speech uses present participle verbs
- [x] Confirm speech timing remains at 7-second intervals  
- [x] Test both TTY and fallback demo modes
- [x] Validate speech bubble rendering works correctly

This makes the robot's tech buzzphrases more engaging and action-focused, better fitting the dynamic Matrix Robot Demo theme.